### PR TITLE
🔒 Bump notebook to fix security alert

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
 
   # Black is used to format the code in Python
   - repo: https://github.com/psf/black
-    rev: 21.10b0
+    rev: 22.3.0
     hooks:
       - id: black
 

--- a/notebooks/demo.ipynb
+++ b/notebooks/demo.ipynb
@@ -921,7 +921,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.8"
+   "version": "3.9.12"
   }
  },
  "nbformat": 4,

--- a/notebooks/push_data.ipynb
+++ b/notebooks/push_data.ipynb
@@ -88,7 +88,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -102,7 +102,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.3"
+   "version": "3.9.12"
   }
  },
  "nbformat": 4,

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ Faker==9.8.1
 glom==20.11.0
 ipywidgets==7.6.5
 matplotlib==3.4.3
-notebook==6.4.4
+notebook==6.4.10
 numpy==1.21.2
 pandas==1.3.3
 pytest==6.2.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,4 @@ python-dotenv==0.19.1
 requests==2.26.0
 scipy==1.7.1
 tqdm==4.62.3
-typer==0.4.0
+typer==0.4.1


### PR DESCRIPTION
## Fixes

<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->

Fixes https://github.com/arkhn/fhir-synthesizer/security/dependabot/1

## Description

<!-- Concisely describe what the pull request does. -->
There was a dependabot alert that urges us to bump notebook, so I did that. I also re-saved the notebooks, to hopefully regenerate the metadata responsible for any potential issue & fix them, but I didn't replay them as I would need to connect to a VPN for that and so on. Note that I didn't investigate the security issue in depth, so I'm not 100% sure it solves what it needs to be solved (I'm not sure either there is something to solve or if it's just in theory that there is a security breach).

@LaRiffle, if we want to be safer, I can also regenerate the notebooks, but we will lose the cells contents (plots mostly), and we can also make the repository private.

## Definition of Done

- [x] I followed the [Arkhn Code Book](https://www.notion.so/arkhn/Arkhn-Code-Book-23ac18a8af7343d0a3f61f1c9ef7400c) (I swear!).
- [ ] I have written tests for the code I added or updated.
- [ ] I have updated the documentation according to my changes.
- [ ] I have updated the deployment configuration if needed.
